### PR TITLE
Tune parameter by modify config file

### DIFF
--- a/Unbias_LightGBM/README.md
+++ b/Unbias_LightGBM/README.md
@@ -1,6 +1,6 @@
 Unbiased_LambdaMart An implementation of Unbiased LambdaMart based on LightGBM (https://github.com/Microsoft/LightGBM). Note that LightGBM contains a wide variety of applications using gradient boosting decision tree algorithms. Our modification is mainly on the src/objective/rank_objective.hpp, which is the LambdaMart Ranking objective file.
 
-There are mainly two hyper-parameters that can be tuned, which you can set by config files. They are:
+There are mainly two hyper-parameters that can be tuned, which you can set by config files(evaluation/configs/train.conf). They are:
 
 ```
   eta = 0.5               : this denotes how much regularization is posed to the position bias.

--- a/Unbias_LightGBM/README.md
+++ b/Unbias_LightGBM/README.md
@@ -1,19 +1,19 @@
 Unbiased_LambdaMart An implementation of Unbiased LambdaMart based on LightGBM (https://github.com/Microsoft/LightGBM). Note that LightGBM contains a wide variety of applications using gradient boosting decision tree algorithms. Our modification is mainly on the src/objective/rank_objective.hpp, which is the LambdaMart Ranking objective file.
 
-There are mainly two hyper-parameters that can be tuned, which is all in the src/objective/rank_objective.hpp files. They are:
+There are mainly two hyper-parameters that can be tuned, which you can set by config files. They are:
 
 ```
-  double _eta               : this denotes how much regularization is posed to the position bias.
-  size_t _position_bins     : this denotes the maximum positions taken into account.
+  eta               : this denotes how much regularization is posed to the position bias.
+  position_bins     : this denotes the maximum positions taken into account.
 ```
 
 If you want to re-implement the result of our table, you can change the regularization term back to 0, by modifying 
 ```
-double _eta = 1.0 / (1 + 0.5); 
+eta = 0.5; 
 ```
-in the src/objective/rank_objective.hpp (Line 418) to 
+in the config file to 
 ```
-double _eta = 1.0 / (1 + 0); 
+double _eta = 0; 
 ```
 
 Another thing need to be noted is that in our Unbiased LambdaMart, each time for running Unbiased LambdaMart, one should prepare the following two files:

--- a/Unbias_LightGBM/README.md
+++ b/Unbias_LightGBM/README.md
@@ -3,8 +3,8 @@ Unbiased_LambdaMart An implementation of Unbiased LambdaMart based on LightGBM (
 There are mainly two hyper-parameters that can be tuned, which you can set by config files. They are:
 
 ```
-  eta               : this denotes how much regularization is posed to the position bias.
-  position_bins     : this denotes the maximum positions taken into account.
+  eta = 0.5               : this denotes how much regularization is posed to the position bias.
+  position_bins =12       : this denotes the maximum positions taken into account.
 ```
 
 If you want to re-implement the result of our table, you can change the regularization term back to 0, by modifying 
@@ -13,7 +13,7 @@ eta = 0.5;
 ```
 in the config file to 
 ```
-double _eta = 0; 
+eta = 0; 
 ```
 
 Another thing need to be noted is that in our Unbiased LambdaMart, each time for running Unbiased LambdaMart, one should prepare the following two files:

--- a/Unbias_LightGBM/include/LightGBM/config.h
+++ b/Unbias_LightGBM/include/LightGBM/config.h
@@ -174,7 +174,7 @@ public:
   // for unbiased lambdarank
   int position_bins = 12;
   // for unbiased lambdarank
-  double eta = 1.0 / (1 + 0.5);
+  double eta = 0.5;
   // for binary
   bool is_unbalance = false;
   // for multiclass
@@ -491,7 +491,7 @@ struct ParameterAlias {
       "zero_as_missing", "init_score_file", "valid_init_score_file", "is_predict_contrib",
       "max_cat_threshold",  "cat_smooth", "min_data_per_group", "cat_l2", "max_cat_to_onehot",
       "alpha", "reg_sqrt", "tweedie_variance_power", "monotone_constraints", "max_delta_step",
-      "forced_splits", "position_bins"
+      "forced_splits", "position_bins", "eta"
     });
     std::unordered_map<std::string, std::string> tmp_map;
     for (const auto& pair : *params) {

--- a/Unbias_LightGBM/include/LightGBM/config.h
+++ b/Unbias_LightGBM/include/LightGBM/config.h
@@ -171,6 +171,10 @@ public:
   std::vector<double> label_gain;
   // for lambdarank
   int max_position = 20;
+  // for unbiased lambdarank
+  int position_bins = 12;
+  // for unbiased lambdarank
+  double eta = 1.0 / (1 + 0.5);
   // for binary
   bool is_unbalance = false;
   // for multiclass
@@ -487,7 +491,7 @@ struct ParameterAlias {
       "zero_as_missing", "init_score_file", "valid_init_score_file", "is_predict_contrib",
       "max_cat_threshold",  "cat_smooth", "min_data_per_group", "cat_l2", "max_cat_to_onehot",
       "alpha", "reg_sqrt", "tweedie_variance_power", "monotone_constraints", "max_delta_step",
-      "forced_splits"
+      "forced_splits", "position_bins"
     });
     std::unordered_map<std::string, std::string> tmp_map;
     for (const auto& pair : *params) {

--- a/Unbias_LightGBM/src/io/config.cpp
+++ b/Unbias_LightGBM/src/io/config.cpp
@@ -336,6 +336,10 @@ void ObjectiveConfig::Set(const std::unordered_map<std::string, std::string>& pa
   CHECK(poisson_max_delta_step > 0);
   GetInt(params, "max_position", &max_position);
   CHECK(max_position > 0);
+  GetInt(params, "position_bins", &position_bins);
+  CHECK(position_bins > 0);
+  GetDouble(params, "eta", &eta);
+  CHECK(eta > 0); 
   GetInt(params, "num_class", &num_class);
   CHECK(num_class > 0);
   GetDouble(params, "scale_pos_weight", &scale_pos_weight);

--- a/Unbias_LightGBM/src/io/config.cpp
+++ b/Unbias_LightGBM/src/io/config.cpp
@@ -339,7 +339,8 @@ void ObjectiveConfig::Set(const std::unordered_map<std::string, std::string>& pa
   GetInt(params, "position_bins", &position_bins);
   CHECK(position_bins > 0);
   GetDouble(params, "eta", &eta);
-  CHECK(eta > 0); 
+  CHECK(eta >= 0); 
+  eta = 1.0/(1.0 + eta);
   GetInt(params, "num_class", &num_class);
   CHECK(num_class > 0);
   GetDouble(params, "scale_pos_weight", &scale_pos_weight);

--- a/Unbias_LightGBM/src/objective/rank_objective.hpp
+++ b/Unbias_LightGBM/src/objective/rank_objective.hpp
@@ -37,6 +37,9 @@ public:
       Log::Fatal("Sigmoid param %f should be greater than zero", sigmoid_);
     }
 
+    _position_bins = config.position_bins;
+    _eta = config.eta;
+
     /// get number of threads
     #pragma omp parallel
     #pragma omp master
@@ -415,9 +418,9 @@ private:
   mutable std::vector<std::vector<label_t>> j_costs_buffer_; ///
 
   /*! \brief Number of exponent */
-  double _eta = 1.0 / (1 + 0.5); ///
+  double _eta; ///
   /*! \brief Number of positions */
-  size_t _position_bins = 12; ///
+  size_t _position_bins; ///
   /*! \brief Cache result for sigmoid transform to speed up */
   std::vector<double> sigmoid_table_;
   /*! \brief Number of bins in simoid table */

--- a/evaluation/configs/train.conf
+++ b/evaluation/configs/train.conf
@@ -105,3 +105,9 @@ local_listen_port = 12400
 
 # machines list file for parallel training, alias: mlist
 machine_list_file = mlist.txt
+
+#how much regularization is posed to the position bias.
+eta = 0.5 
+
+#maximum positions taken into account for position bias.
+position_bins = 12


### PR DESCRIPTION
Tune eta and position_bins need re-compile lightgbm. I add 2 parameters into config file, so that we  only need modify config file. And the eta now is same as the regularization norm in the paper.